### PR TITLE
[BUGFIX] JWT base64 인코딩 특수문자 생성 오류

### DIFF
--- a/src/main/java/com/sparta/filmfly/global/auth/JwtProvider.java
+++ b/src/main/java/com/sparta/filmfly/global/auth/JwtProvider.java
@@ -45,7 +45,9 @@ public class JwtProvider {
 
         String token = builder.compact();
         // Base64 URL-safe encoding
-        return Base64.getUrlEncoder().encodeToString(token.getBytes());
+//        String encodingToken = Base64.getUrlEncoder().encodeToString(token.getBytes());
+//        log.info("encodingToken : {}", encodingToken);
+        return token;
     }
 
     public String createAccessToken(String username) {
@@ -59,14 +61,14 @@ public class JwtProvider {
     }
 
     public Claims getUserInfoFromToken(String token) {
-        String decodedToken = new String(Base64.getUrlDecoder().decode(token));
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(decodedToken).getBody();
+//        String decodedToken = new String(Base64.getUrlDecoder().decode(token));
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
     }
 
     public boolean validateToken(String token) {
         try {
-            String decodedToken = new String(Base64.getUrlDecoder().decode(token));
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(decodedToken);
+//            String decodedToken = new String(Base64.getUrlDecoder().decode(token));
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (SecurityException | MalformedJwtException e) {
             log.error("유효하지 않는 JWT 서명 또는 잘못된 토큰 입니다.");

--- a/src/test/http/HttpLoginTokenTest.http
+++ b/src/test/http/HttpLoginTokenTest.http
@@ -1,0 +1,35 @@
+### ADMIN 로그인
+POST http://localhost:8080/users/login
+Content-Type: application/json
+
+{
+  "username" : "admin1",
+  "password": "Test123!@"
+}
+### ADMIN 로그인 2
+POST http://localhost:8080/users/login
+Content-Type: application/json
+
+{
+  "username" : "admin2221",
+  "password": "Test123!22"
+}
+
+### ADMIN 로그인 2
+POST http://localhost:8080/users/login
+Content-Type: application/json
+
+{
+  "username" : "admin222",
+  "password": "Test123!22"
+}
+### ADMIN 회원가입 2
+POST http://localhost:8080/users/signup
+Content-Type: application/json
+
+{
+  "username": "admin222132",
+  "password": "Test123!22",
+  "email" : "dmarb0313@gmail.com",
+  "adminPassword": "1234"
+}

--- a/src/test/http/HttpPasswordModifyTest.http
+++ b/src/test/http/HttpPasswordModifyTest.http
@@ -1,0 +1,56 @@
+### ADMIN 회원가입
+POST http://localhost:8080/users/signup
+Content-Type: application/json
+
+{
+  "username": "admin1231",
+  "password": "Test123!",
+  "email" : "dmarb0313@gmail.com",
+  "adminPassword": "1234"
+}
+
+### ADMIN 로그인
+POST http://localhost:8080/users/login
+Content-Type: application/json
+
+{
+  "username" : "admin1231",
+  "password": "Test123!"
+}
+
+### User Password 수정
+PUT http://localhost:8080/users/password
+Content-Type: application/json
+
+{
+  "currentPassword": "Test123!",
+  "newPassword": "Test123!@"
+}
+### ADMIN 회원가입
+POST http://localhost:8080/users/signup
+Content-Type: application/json
+
+{
+  "username": "admin12312",
+  "password": "Test123!",
+  "email" : "dmarb0313@gmail.com",
+  "adminPassword": "1234"
+}
+
+### ADMIN 로그인
+POST http://localhost:8080/users/login
+Content-Type: application/json
+
+{
+  "username" : "admin12312",
+  "password": "Test123!"
+}
+
+### User Password 수정
+PUT http://localhost:8080/users/password
+Content-Type: application/json
+
+{
+  "currentPassword": "Test123!",
+  "newPassword": "Test123!@"
+}


### PR DESCRIPTION
- 거의 비슷하지만 username에서 끝부분만 약간 다른 두 아이디를 생성하고 로그인 했을때 토큰값 인코딩 끝부분에 = 특수문자가 붙어 생성됨
- base64 인코딩 로직을 제거해서 해결

closed #78 